### PR TITLE
specify build string

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,9 @@ source:
   git_rev: v{{ version }}
 
 build:
-  number: 1
+  number: 2
   noarch: python
+  string: py_{{ PKG_BUILDNUM }}
   
 requirements:
   build:


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Let's specify the build string here on noarch packages since the default strings differ when built on different architectures. This will help when automation combines multiple different output directories (from different arches for example) into a single channel without having duplicates.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
