### PR TITLE
adjust protobuf location

### DIFF
--- a/recipe/0001-adjust-protobuf-github-repo.patch
+++ b/recipe/0001-adjust-protobuf-github-repo.patch
@@ -1,0 +1,25 @@
+From 80fba698ff47dd122a8fbb083c8433cba5933e84 Mon Sep 17 00:00:00 2001
+From: Jason Furmanek <furmanek@us.ibm.com>
+Date: Wed, 28 Jul 2021 13:19:30 -0400
+Subject: [PATCH] adjust protobuf github repo
+
+---
+ WORKSPACE | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/WORKSPACE b/WORKSPACE
+index 495ed63..c9ba72e 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -22,7 +22,7 @@ git_repository(
+     name = "com_google_protobuf",
+     # v3.8.0
+     commit = "09745575a923640154bcf307fba8aedff47f240a",
+-    remote = "https://github.com/google/protobuf.git",
++    remote = "https://github.com/protocolbuffers/protobuf.git",
+ )
+ 
+ # Required by protobuf 3.8.0.
+-- 
+2.23.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,11 @@ package:
 source:
   git_url: https://github.com/tensorflow/hub.git
   git_rev: v{{ version }}
+  patches:
+    - 0001-adjust-protobuf-github-repo.patch
 
 build:
-  number: 3
+  number: 4
   noarch: python
   string: py_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

protobuf has migrated to http://github.com/protocolbuffers/protobuf
This patches this new location for tensorflow hub 0.12

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
