### PR TITLE
Updated zlib 1.2.11 archive URL

### DIFF
--- a/recipe/0301-Updated-zlib-url.patch
+++ b/recipe/0301-Updated-zlib-url.patch
@@ -16,7 +16,8 @@ index 495ed63..9a33f35 100644
      sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
      strip_prefix = "zlib-1.2.11",
 -    urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
-+    urls = ["https://zlib.net/zlib-1.2.11.tar.gz", "https://fossies.org/linux/misc/zlib-1.2.11.tar.gz"],
++    urls = ["https://zlib.net/zlib-1.2.11.tar.gz", "https://www.zlib.net/fossils/zlib-1.2.12.tar.gz"],
+
  )
  
  # Required by protobuf 3.8.0.

--- a/recipe/0301-Updated-zlib-url.patch
+++ b/recipe/0301-Updated-zlib-url.patch
@@ -1,14 +1,14 @@
-From ca1ef2f8b8279e421d9ea79bbec3683e178b9b51 Mon Sep 17 00:00:00 2001
+From 1b064e089ff3dda10807caf89d25d9f594ab9959 Mon Sep 17 00:00:00 2001
 From: Nishidha Panpaliya <npanpa23@in.ibm.com>
-Date: Mon, 28 Mar 2022 04:59:43 -0400
-Subject: [PATCH] Updated zlib url
+Date: Tue, 29 Mar 2022 03:50:50 -0400
+Subject: [PATCH] Updated zlib URL
 
 ---
  WORKSPACE | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/WORKSPACE b/WORKSPACE
-index 495ed63..9a33f35 100644
+index 495ed63..c2656e2 100644
 --- a/WORKSPACE
 +++ b/WORKSPACE
 @@ -31,7 +31,7 @@ http_archive(
@@ -16,8 +16,7 @@ index 495ed63..9a33f35 100644
      sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
      strip_prefix = "zlib-1.2.11",
 -    urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
-+    urls = ["https://zlib.net/zlib-1.2.11.tar.gz", "https://www.zlib.net/fossils/zlib-1.2.12.tar.gz"],
-
++    urls = ["https://zlib.net/zlib-1.2.11.tar.gz", "https://www.zlib.net/fossils/zlib-1.2.11.tar.gz"],
  )
  
  # Required by protobuf 3.8.0.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0301-Updated-zlib-url.patch
 
 build:
-  number: 7
+  number: 8
   noarch: python
   string: pyh{{ PKG_HASH }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

zlib 1.2.12 is released two days ago, and hence 1.2.11 went  into archived location. Updated the zlib URL again to use the right one.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
